### PR TITLE
user could press search when there was no city or region selected - c…

### DIFF
--- a/src/components/Account/Account.jsx
+++ b/src/components/Account/Account.jsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { UserContext } from "../../global/user/UserContext";
 import useLocalStorage from "../../hooks/useLocalStorage";
@@ -8,22 +8,22 @@ import AccountForm from "./AccountForm";
 import { addAllChoice, removeAllChoice } from "../../global/choice/actions";
 import { ChoiceContext } from "../../global/choice/context";
 import {
-  removeAllItinerary,
   addAllItinerary,
   addAllItineraryLandmark,
+  removeAllItinerary,
 } from "../../global/itinerary/actions";
+import { ItineraryContext } from "../../global/itinerary/context";
 import useFetchUsers from "../../hooks/useFetchUsers";
+import { Error } from "../Contact/Contact.style";
+import { InfoUser } from "../Explore/Explore.style";
 import {
+  AccountSection,
   ButtonsContainerAccount,
   ContactButton,
   ContactContainer,
   ContactText,
   InputContainerAccount,
-  AccountSection,
 } from "./Account.style";
-import { ItineraryContext } from "../../global/itinerary/context";
-import { InfoUser } from "../Explore/Explore.style";
-import { Error } from "../Contact/Contact.style";
 
 const Account = () => {
   const navigate = useNavigate();
@@ -40,8 +40,7 @@ const Account = () => {
 
   const [isVisible1, setIsVisible1] = useState(false);
   const [isVisible2, setIsVisible2] = useState(false);
-  const buttonRef1 = useRef(null);
-  const buttonRef2 = useRef(null);
+  const [splitContainer, setSplitContainer] = useState(false);
 
   const [message, setMessage] = useState(false);
 
@@ -71,19 +70,19 @@ const Account = () => {
 
   const handleGetAccount = () => {
     setIsVisible1(!isVisible1);
+    setSplitContainer(!splitContainer);
     setIsVisible2(false);
     setError(false);
     setIsFound(true);
-    !isVisible1 ? buttonRef1.current.focus() : buttonRef1.current.blur();
     setInputObj({ Email: "" }); //reset input field
   };
 
   const handleNewAccount = () => {
     setIsVisible2(!isVisible2);
+    setSplitContainer(!splitContainer);
     setIsVisible1(false);
     setError(false);
     setIsFound(false);
-    !isVisible2 ? buttonRef2.current.focus() : buttonRef2.current.blur();
     setInputObj({ Email: "" }); //reset input field
   };
 
@@ -160,6 +159,7 @@ const Account = () => {
   const logoutUser = () => {
     setIsVisible1(false); //closes login form
     setIsVisible2(false); //closes new account form
+    setSplitContainer(false);
     resetLocalData();
     setUser(null);
     dispatchChoice(removeAllChoice());
@@ -190,12 +190,10 @@ const Account = () => {
     <AccountSection loc="AccountSection">
       <ButtonsContainerAccount
         loc="ButtonsContainerAccount"
-        isVisible1={isVisible1} //prop for css
-        isVisible2={isVisible2} //prop for css
+        split={splitContainer ? "true" : "false"}
       >
         <Buttons
           loc="Buttons"
-          ref={buttonRef1}
           variant="account" //prop for css
           onClick={() => handleGetAccount()}
         >
@@ -203,7 +201,6 @@ const Account = () => {
         </Buttons>
         <Buttons
           loc="Buttons"
-          ref={buttonRef2}
           variant="account" //prop for css
           onClick={() => handleNewAccount()}
         >
@@ -219,8 +216,7 @@ const Account = () => {
       </ButtonsContainerAccount>
       <InputContainerAccount
         loc="InputContainerAccount"
-        isVisible1={isVisible1} //prop for css
-        isVisible2={isVisible2} //prop for css
+        split={splitContainer ? "true" : "false"}
       >
         {isVisible1 && (
           <ContactContainer loc="ContactContainer">

--- a/src/components/Account/Account.style.js
+++ b/src/components/Account/Account.style.js
@@ -73,8 +73,7 @@ export const ButtonsContainerAccount = styled.div`
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: ${(props) =>
-    props.isVisible1 || props.isVisible2 ? "50%" : "unset"};
+  height: ${(props) => (props.split == "true" ? "50%" : "unset")};
 
   @media screen and (max-width: 630px) {
     flex-direction: column;
@@ -84,8 +83,7 @@ export const InputContainerAccount = styled.div`
   display: flex;
   font-size: 15px;
   width: 100%;
-  height: ${(props) =>
-    props.isVisible1 || props.isVisible2 ? "50%" : "unset"};
+  height: ${(props) => (props.split == "true" ? "50%" : "unset")};
   flex-direction: column;
   align-content: center;
   align-items: center;

--- a/src/components/MainHome/CitiesRegions/CitiesRegions.jsx
+++ b/src/components/MainHome/CitiesRegions/CitiesRegions.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Spinner from "react-bootstrap/Spinner";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import useFetchData from "../../../hooks/useFetchData";
 import useLocalStorage from "../../../hooks/useLocalStorage";
 import Attributions from "../../Attributions/Attributions";
@@ -23,16 +23,17 @@ import {
 
 function CitiesRegions() {
   const { country } = useParams();
+  const navigate = useNavigate();
 
   const { localData } = useLocalStorage("user");
   console.log("localData", localData);
 
   console.log("country", country, "id", localData);
   const [clicked, setClicked] = useState(true);
-  const [show, setShow] = useState(null);
   const [city, setCity] = useState("");
   const [region, setRegion] = useState("");
-
+  const [isDisabledCity, setIsDisabledCity] = useState(false);
+  const [isDisabledRegion, setIsDisabledRegion] = useState(false);
   const url = country ? `http://localhost:3001/${country}` : null;
 
   const { data, error, loading } = useFetchData(url, clicked, setClicked);
@@ -41,17 +42,24 @@ function CitiesRegions() {
 
   const onOptionChangeCity = (e) => {
     setCity(e.target.value);
+    setRegion("");
   };
 
   const onOptionChangeRegion = (e) => {
     setRegion(e.target.value);
+    setCity("");
   };
-  const changeCityRegion = (city) => {
-    if (city === "city") {
-      setShow(true);
-    } else {
-      setShow(false);
-    }
+
+  const goRegion = (event) => {
+    region !== ""
+      ? navigate(`/my-travel2/${country}/${region}/${localData}`)
+      : event.preventDefault();
+  };
+
+  const goCity = (event) => {
+    city !== ""
+      ? navigate(`/my-travel1/${country}/${city}/${localData}`)
+      : event.preventDefault();
   };
 
   return (
@@ -85,8 +93,12 @@ function CitiesRegions() {
             <DataContainer loc="DataContainer">
               <FiltersContainer
                 loc="FiltersContainer"
-                show={show}
-                onClick={() => changeCityRegion("city")}
+                disabled={isDisabledCity}
+                onMouseOver={() => {
+                  setIsDisabledCity(false);
+                  setIsDisabledRegion(true);
+                }}
+                onMouseOut={() => setIsDisabledRegion(false)}
               >
                 <SelectCity
                   loc="SelectCity"
@@ -98,17 +110,18 @@ function CitiesRegions() {
                     return e.city && <GetOption key={index} value={e.city} />;
                   })}
                 </SelectCity>
-                <ButtonPlan
-                  loc="ButtonPlan"
-                  to={`/my-travel1/${country}/${city}/${localData}`}
-                >
+                <ButtonPlan loc="ButtonPlan" onClick={(event) => goCity(event)}>
                   Search
                 </ButtonPlan>
               </FiltersContainer>
               <FiltersContainer
                 loc="FiltersContainer"
-                show={!show}
-                onClick={() => changeCityRegion("region")}
+                disabled={isDisabledRegion}
+                onMouseOver={() => {
+                  setIsDisabledRegion(false);
+                  setIsDisabledCity(true);
+                }}
+                onMouseOut={() => setIsDisabledCity(false)}
               >
                 <SelectRegion
                   loc="SelectRegion"
@@ -124,7 +137,7 @@ function CitiesRegions() {
                 </SelectRegion>
                 <ButtonPlan
                   loc="ButtonPlan"
-                  to={`/my-travel2/${country}/${region}/${localData}`}
+                  onClick={(event) => goRegion(event)}
                 >
                   Search
                 </ButtonPlan>

--- a/src/components/MainHome/CitiesRegions/CitiesRegions.style.js
+++ b/src/components/MainHome/CitiesRegions/CitiesRegions.style.js
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { DARK_BLUE, ORANGE, WHITE_NEUTRAL } from "../../../constants/Colors";
-import { Link } from "react-router-dom";
 import { TEXT_SIZE_MEDIUM } from "../../../constants/Dimensions";
 
 export const PageContainer = styled.div`
@@ -17,7 +16,7 @@ export const FiltersContainer = styled.div`
   width: 90%;
   margin: 50px auto;
   border: 2px solid ${WHITE_NEUTRAL};
-  ${(props) => props.show !== null && `opacity: ${props.show ? "1" : "0.5"};`};
+  opacity: ${(props) => (props.disabled ? "0.5" : "1")};
 `;
 
 export const MainContainer = styled.div`
@@ -64,7 +63,7 @@ export const TextContainer = styled.p`
   text-align: justify;
 `;
 
-export const ButtonPlan = styled(Link)`
+export const ButtonPlan = styled.button`
   width: 200px;
   height: 40px;
   font-weight: 700;

--- a/src/components/MyTravelCity/MyTravelCity.jsx
+++ b/src/components/MyTravelCity/MyTravelCity.jsx
@@ -62,9 +62,11 @@ function MyTravelCity() {
   };
 
   const handleClick = () => {
-    setPeriod(period);
-    setBudget(budget);
-    setShow(!show);
+    if (period !== "" || budget !== "") {
+      setShow(true);
+    } else {
+      setShow(false);
+    }
   };
 
   const id = localData;
@@ -173,18 +175,18 @@ function MyTravelCity() {
                 <FiltersTravel loc="FiltersTravel">
                   <ButtonPlanTravel
                     loc="ButtonPlanTravel"
-                    onClick={handleClick}
+                    onClick={() => handleClick()}
                   >
                     Search
                   </ButtonPlanTravel>
                 </FiltersTravel>
-                {show ? (
+                {show && (
                   <MyTravelRecommend
                     budgetTravel={budget}
                     periodTravel={period}
                     data={data}
                   />
-                ) : null}
+                )}
               </FiltersContainerTravel>
             )}
           </>
@@ -192,7 +194,7 @@ function MyTravelCity() {
         {data && (!data[0].budget || !data[0].period) && (
           <div>No data available for your selection!</div>
         )}
-        {show ? (
+        {show && (
           <ButtonChoice
             loc="ButtonChoice"
             to={`/my-choices`}
@@ -202,7 +204,7 @@ function MyTravelCity() {
           >
             Save my Choice
           </ButtonChoice>
-        ) : null}
+        )}
       </PageContainerTravel>
     </>
   );

--- a/src/components/MyTravelRegion/MyTravelRegion.jsx
+++ b/src/components/MyTravelRegion/MyTravelRegion.jsx
@@ -3,6 +3,7 @@ import Spinner from "react-bootstrap/Spinner";
 import { useParams } from "react-router-dom";
 import { addChoice } from "../../global/choice/actions";
 import { ChoiceContext } from "../../global/choice/context";
+import transformToUppercase from "../../global/utilities/transformToUppercase";
 import useFetchData from "../../hooks/useFetchData";
 import useFetchUsers from "../../hooks/useFetchUsers";
 import useLocalStorage from "../../hooks/useLocalStorage";
@@ -61,9 +62,11 @@ function MyTravelRegion() {
   };
 
   const handleClick = () => {
-    setPeriod(period);
-    setBudget(budget);
-    setShow(!show);
+    if (period !== "" || budget !== "") {
+      setShow(true);
+    } else {
+      setShow(false);
+    }
   };
 
   const id = localData;
@@ -169,23 +172,26 @@ function MyTravelRegion() {
               </FiltersTravel>
 
               <FiltersTravel loc="FiltersTravel">
-                <ButtonPlanTravel loc="ButtonPlanTravel" onClick={handleClick}>
+                <ButtonPlanTravel
+                  loc="ButtonPlanTravel"
+                  onClick={() => handleClick()}
+                >
                   Search
                 </ButtonPlanTravel>
               </FiltersTravel>
 
-              {show ? (
+              {show && (
                 <MyTravelRecommend
                   budgetTravel={budget}
                   periodTravel={period}
                   data={data}
                 />
-              ) : null}
+              )}
             </FiltersContainerTravel>
           </>
         )}
 
-        {show ? (
+        {show && (
           <ButtonChoice
             loc="ButtonChoice"
             to={`/my-choices`}
@@ -193,7 +199,7 @@ function MyTravelRegion() {
           >
             Save my Choice
           </ButtonChoice>
-        ) : null}
+        )}
       </PageContainerTravel>
     </>
   );


### PR DESCRIPTION
user could press search when there was no city or region selected - citiesregions - solved by checking if a selection was made and preventing event if no selection; also added in citiesregions a visual disabled effect when city or region selection is not hovered upon with cursor; user could press search when there was no period or budget selected - solved by checking if a selection was made - also improved logic when selection exists; removed unnecessary useRef constants from account - functionality is made in css; improved logic when there is a 50/50 split container (when login or new account is pressed); impoved css for mentioned problems in citiesregions and account