### PR TITLE
hide toast automatically so it will be not visible if we navigate bac…

### DIFF
--- a/src/components/Account/Account.jsx
+++ b/src/components/Account/Account.jsx
@@ -31,7 +31,7 @@ const Account = () => {
   const [clicked, setClicked] = useState(false);
   let id = "";
 
-  const { user, setUser, fetchUser } = useContext(UserContext); // destructurare UserContext
+  const { user, setUser } = useContext(UserContext); // destructurare UserContext
 
   const { users, error, loading, setError } = useFetchUsers(
     id,
@@ -67,7 +67,7 @@ const Account = () => {
     stateGlobalItinerary
   );
 
-  const { showToast } = useToast();
+  const { showToast, hideToast } = useToast();
 
   //enter login section
   const handleGetAccount = () => {

--- a/src/global/toast/ToastContext.jsx
+++ b/src/global/toast/ToastContext.jsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 
 const ToastContext = createContext();
 
@@ -10,6 +11,8 @@ export const ToastProvider = ({ children }) => {
     showT: false,
   });
 
+  const location = useLocation();
+
   const showToast = (title, text, className) => {
     setToastData({ title, text, className, showT: true });
   };
@@ -17,6 +20,12 @@ export const ToastProvider = ({ children }) => {
   const hideToast = () => {
     setToastData((prev) => ({ ...prev, showT: false }));
   };
+
+  //hide toast automatically so it will be not visible if we navigate back to the same page
+  //hide toast just if changes in URL
+  useEffect(() => {
+    hideToast();
+  }, [location.pathname]);
 
   return (
     <ToastContext.Provider value={{ toastData, showToast, hideToast }}>

--- a/src/global/user/UserContext.jsx
+++ b/src/global/user/UserContext.jsx
@@ -26,7 +26,7 @@ export const UserProvider = ({ children }) => {
   };
 
   return (
-    <UserContext.Provider value={{ user, setUser, fetchUser }}>
+    <UserContext.Provider value={{ user, setUser }}>
       {children}
     </UserContext.Provider>
   );


### PR DESCRIPTION
hide toast automatically so it will be not visible if we navigate back to the same page; removed fetchUser as global value in UserContext - it is needed just locally in UserContext function